### PR TITLE
bootstrap 'validate' subcommand and module

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
+mod validate;
+
 #[macro_use]
 extern crate log;
 
 use env_logger::Builder;
 use log::LevelFilter;
+use std::path::PathBuf;
 use structopt::StructOpt;
 use structopt_flags::GetWithDefault;
 
@@ -14,6 +17,21 @@ use structopt_flags::GetWithDefault;
 struct Args {
     #[structopt(flatten)]
     verbose: structopt_flags::VerboseNoDef,
+
+    #[structopt(subcommand)]
+    cmd: SubCmd,
+}
+
+#[derive(StructOpt, Debug)]
+enum SubCmd {
+    #[structopt(name = "validate", about = "Validate given configuration file")]
+    Validate(ValidateCmdOpts),
+}
+
+#[derive(StructOpt, Debug)]
+pub struct ValidateCmdOpts {
+    /// Configuration file to validate
+    input_file: PathBuf,
 }
 
 fn main() {
@@ -22,5 +40,7 @@ fn main() {
     let log_level = args.verbose.get_with_default(LevelFilter::Info);
     Builder::from_default_env().filter_level(log_level).init();
 
-    info!("hello, world!");
+    match args.cmd {
+        SubCmd::Validate(opts) => validate::handle(opts),
+    }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,0 +1,5 @@
+use crate::ValidateCmdOpts;
+
+pub fn handle(opts: ValidateCmdOpts) {
+    info!("hello, validate! These are my options: {:?}", opts);
+}


### PR DESCRIPTION
The subcommand `helm-templexer validate` will be used to check any given configuration file for correctness.