### PR TITLE
allow for passing multiple files to `validate`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,8 @@ enum SubCmd {
 
 #[derive(StructOpt, Debug)]
 pub struct ValidateCmdOpts {
-    // TODO support passing in multiple files?
-    /// Configuration file to validate (supported formats: toml, yaml, json)
-    input_file: PathBuf,
+    /// Configuration file(s) to validate (supported formats: toml, yaml, json)
+    input_files: Vec<PathBuf>,
 
     #[structopt(short, long, about = "Skip validation if `enabled` is set to false")]
     skip_disabled: bool,

--- a/src/validate_cmd.rs
+++ b/src/validate_cmd.rs
@@ -19,7 +19,9 @@ impl ValidateCmd {
     pub fn run(&mut self) -> Result<()> {
         debug!("validation options: {:?}", self.opts);
 
-        Config::load(&self.opts.input_file)?.validate(&ValidationOpts::default())?;
+        for file in &self.opts.input_files {
+            Config::load(&file)?.validate(&ValidationOpts::default())?;
+        }
 
         Ok(())
     }

--- a/tests/data/config_example.json
+++ b/tests/data/config_example.json
@@ -1,0 +1,48 @@
+{
+  "version": "v1",
+  "enabled": true,
+  "chart": "nginx-chart",
+  "namespace": "my-namespace",
+  "release_name": "my-app-edge",
+  "output_path": "manifests",
+  "additional_options": [
+    "--skip-crds",
+    "--no-hooks"
+  ],
+  "values": [
+    "nginx-chart/values/default.yaml"
+  ],
+  "deployments": [
+    {
+      "name": "edge-eu-w4",
+      "values": [
+        "nginx-chart/values/edge.yaml"
+      ],
+      "additional_options": [
+        "--set image.tag=latest"
+      ]
+    },
+    {
+      "name": "next-edge-eu-w4",
+      "enabled": false,
+      "release_name": "my-app-edge-next",
+      "values": [
+        "nginx-chart/values/edge.yaml",
+        "nginx-chart/values/next-edge.yaml"
+      ]
+    },
+    {
+      "name": "stage-eu-w4",
+      "values": [
+        "nginx-chart/values/stage.yaml"
+      ]
+    },
+    {
+      "name": "prod-eu-w4",
+      "values": [
+        "nginx-chart/values/prod.yaml",
+        "nginx-chart/values/prod-eu-w4.yaml"
+      ]
+    }
+  ]
+}

--- a/tests/data/config_example.yaml
+++ b/tests/data/config_example.yaml
@@ -1,3 +1,4 @@
+---
 version: v1
 enabled: true
 chart: nginx-chart
@@ -5,26 +6,26 @@ namespace: my-namespace
 release_name: my-app-edge
 output_path: manifests
 additional_options:
-  - '--skip-crds'
-  - '--no-hooks'
+  - "--skip-crds"
+  - "--no-hooks"
 values:
-  - ../../values/default.yaml
+  - nginx-chart/values/default.yaml
 deployments:
   - name: edge-eu-w4
     values:
-      - ../../values/my-app/values-edge.yaml
+      - nginx-chart/values/edge.yaml
     additional_options:
-      - '--set image.tag=latest'
+      - "--set image.tag=latest"
   - name: next-edge-eu-w4
     enabled: false
     release_name: my-app-edge-next
     values:
-      - ../../values/my-app/values-edge.yaml
-      - ../../values/my-app/values-next-edge.yaml
+      - nginx-chart/values/edge.yaml
+      - nginx-chart/values/next-edge.yaml
   - name: stage-eu-w4
     values:
-      - ../../values/my-app/values-stage.yaml
+      - nginx-chart/values/stage.yaml
   - name: prod-eu-w4
     values:
-      - ../../values/my-app/values-prod.yaml
-      - ../../values/my-app/values-prod-eu-w4.yaml
+      - nginx-chart/values/prod.yaml
+      - nginx-chart/values/prod-eu-w4.yaml

--- a/tests/data/gen_cfg.sh
+++ b/tests/data/gen_cfg.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+refmt -i config_example.toml --input-format toml -o config_example.yaml --output-format yaml
+refmt -i config_example.toml --input-format toml -o config_example.json --output-format json

--- a/tests/test_validator.rs
+++ b/tests/test_validator.rs
@@ -41,3 +41,17 @@ fn chart_does_not_exist() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn validate_accepts_multiple_files() -> Result<()> {
+    let mut cmd = Command::cargo_bin("helm-templexer")?;
+
+    cmd.current_dir("tests/data")
+        .arg("validate")
+        .arg("config_example.toml")
+        .arg("config_example.yaml")
+        .arg("config_example.json");
+    cmd.assert().success();
+
+    Ok(())
+}


### PR DESCRIPTION
- add conversion script using `refmt` to generate
  yaml and json configs from the toml example file

  see https://github.com/yoshihitoh/refmt