### PR TITLE
"PathBuf to str" and use Path when possible 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde::Deserialize;
+use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Deserialize, Debug)]
@@ -62,8 +63,8 @@ pub struct ValidationOpts {
 impl Config {
     /// Load given configuration file and deserialize it.
     /// Does not call Config::validate - only checks the path and runs Serde
-    pub fn load(file: &PathBuf) -> Result<Config> {
-        Self::check_file_exists_and_readable(&file)?;
+    pub fn load<S: AsRef<Path>>(file: S) -> Result<Config> {
+        Self::check_file_exists_and_readable(&file.as_ref())?;
 
         match serde_any::from_file(file) {
             Ok(cfg) => Ok(cfg),
@@ -92,7 +93,7 @@ impl Config {
     }
 
     /// Check whether the given input file exists and is readable
-    fn check_file_exists_and_readable(input_file: &PathBuf) -> Result<()> {
+    fn check_file_exists_and_readable(input_file: &Path) -> Result<()> {
         if !input_file.exists() {
             bail!("File {:?} does not exist or is not readable", input_file);
         }
@@ -181,13 +182,13 @@ mod tests {
     #[should_panic]
     fn input_file_does_not_exist() {
         // TODO feels more like an integration test, rather than a unit test
-        Config::load(&PathBuf::from("does-not-exist")).unwrap();
+        Config::load("does-not-exist").unwrap();
     }
 
     #[test]
     fn input_file_exists() {
         // TODO feels more like an integration test, rather than a unit test
-        Config::load(&PathBuf::from("tests/data/config_example.toml")).unwrap();
+        Config::load("tests/data/config_example.toml").unwrap();
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,16 +54,9 @@ pub struct Deployment {
     pub values: Option<Vec<PathBuf>>,
 }
 
+#[derive(Default)]
 pub struct ValidationOpts {
     pub skip_disabled: bool,
-}
-
-impl Default for ValidationOpts {
-    fn default() -> Self {
-        Self {
-            skip_disabled: false,
-        }
-    }
 }
 
 impl Config {

--- a/src/render_cmd.rs
+++ b/src/render_cmd.rs
@@ -76,7 +76,6 @@ impl RenderCmd {
             }
         }
 
-        // todo is it really that hard to get from PathBuf to String?
         let chart = match cfg.chart.to_str() {
             Some(s) => s,
             None => bail!(
@@ -169,7 +168,6 @@ impl RenderCmd {
                 cmd.join(" ")
             );
 
-            // todo allow the user to disable cleanup of the output path?
             match &plan.output_paths.get(deployment) {
                 Some(p) => {
                     debug!("cleaning up output path: {:?}", p);
@@ -220,22 +218,17 @@ impl RenderCmd {
     }
 
     /// Utility to turn an option for a vector of pathbufs into a vector of strings
-    /// todo is it really that hard to go from a Vec<PathBuf> to a Vec<String>?
     fn get_values_as_strings(&self, input: &Option<Vec<PathBuf>>) -> Result<Vec<String>> {
         let mut buffer: Vec<String> = vec![];
 
-        match input {
-            Some(items) => {
-                for i in items {
-                    match i.clone().into_os_string().into_string() {
-                        Ok(s) => buffer.push(s),
-                        Err(s) => bail!("failed to convert {:?} to string", s),
-                    }
+        if let Some(items) = input {
+            for i in items {
+                match i.to_str() {
+                    Some(s) => buffer.push(s.to_string()),
+                    None => bail!("failed to convert {:?} to string", i),
                 }
             }
-            None => (),
         }
-
         Ok(buffer)
     }
 }

--- a/src/render_cmd.rs
+++ b/src/render_cmd.rs
@@ -77,17 +77,17 @@ impl RenderCmd {
         }
 
         // todo is it really that hard to get from PathBuf to String?
-        let chart = match cfg.chart.clone().into_os_string().into_string() {
-            Ok(s) => s,
-            Err(_) => bail!(
+        let chart = match cfg.chart.to_str() {
+            Some(s) => s,
+            None => bail!(
                 "failed to convert given chart path {:?} to string",
                 cfg.chart
             ),
         };
 
-        let output_dir = match cfg.output_path.clone().into_os_string().into_string() {
-            Ok(s) => s,
-            Err(_) => bail!(
+        let output_dir = match cfg.output_path.to_str() {
+            Some(s) => s,
+            None => bail!(
                 "failed to convert given output_path {:?} to string",
                 cfg.output_path
             ),
@@ -103,7 +103,7 @@ impl RenderCmd {
         base_cmd.push("helm".to_string());
         base_cmd.push("template".to_string());
         base_cmd.push(cfg.release_name.clone());
-        base_cmd.push(chart);
+        base_cmd.push(chart.to_string());
 
         match &cfg.namespace {
             Some(namespace) => base_cmd.push(format!("--namespace={}", namespace)),


### PR DESCRIPTION
I've noticed the todo and suggest in this PR an easier way to convert PathBuf to str, converting to String only when needed.

While here:
* derive Default for ValidationOpts
* adopt &Path instead of &PathBuf, allowing to directly use str in Config.load()