### PR TITLE
Update Rust Release Binary Action

### DIFF
--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Compile and release
-        uses: rust-build/rust-build.action@v1.0.0
+        uses: rust-build/rust-build.action@v1.0.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUSTTARGET: ${{ matrix.target }}


### PR DESCRIPTION
This changeset updates the version of the marketplace binary used for our rust code release. This addresses the open[ issue number 42](https://github.com/hendrikmaus/helm-templexer/issues/42#issue-860024519)