### PR TITLE
Add minimal configuration for release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## Changelog
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Update Release Draft
     steps:
+      - uses: actions/checkout@v2
       - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-20.04
+    name: Update Release Draft
     steps:
       - uses: release-drafter/release-drafter@v5
         env:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I propose for us to try https://github.com/marketplace/actions/release-drafter to create automatic changelogs for the github releases.