### PR TITLE
Add an additional cache key, stable over multiple jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,6 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-        with:
-          sharedKey: shared-cache
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -45,8 +43,6 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-        with:
-          sharedKey: shared-cache
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -62,8 +58,6 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-        with:
-          sharedKey: shared-cache
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:
@@ -81,8 +75,6 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-        with:
-          sharedKey: shared-cache
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: shared-cache
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -43,6 +45,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: shared-cache
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -58,6 +62,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: shared-cache
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:
@@ -75,6 +81,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: shared-cache
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,9 @@ jobs:
         target: [x86_64-unknown-linux-musl]
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: shared-cache
       - name: Compile and release
         uses: rust-build/rust-build.action@v1.0.3
         env:
@@ -35,6 +38,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: shared-cache
       - uses: katyo/publish-crates@v1
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -52,6 +57,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: shared-cache
       - name: Build binary
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
The shared cache key allows multiple jobs that do the same thing to leverage the caching. Otherwise, each job would have its own cache.