### PR TITLE
Update rust-build action and add darwin support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-unknown-linux-musl]
+        target: [x86_64-unknown-linux-musl, x86_64-apple-darwin]
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
         with:
           sharedKey: shared-cache
       - name: Compile and release
-        uses: rust-build/rust-build.action@v1.0.3
+        uses: rust-build/rust-build.action@v1.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUSTTARGET: ${{ matrix.target }}


### PR DESCRIPTION
This changeset updates https://github.com/rust-build/rust-build.action to the latest version and also adds a binary for Apple computers. 