### PR TITLE
Use latest version of rust-build.action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,15 +21,12 @@ jobs:
         with:
           sharedKey: shared-cache
       - name: Compile and release
-        # Switch back to the upstream action once https://github.com/rust-build/rust-build.action/pull/17 was released
-        #uses: rust-build/rust-build.action@v1.1.0
-        uses: hendrikmaus/rust-build.action@master
+        uses: rust-build/rust-build.action@v1.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUSTTARGET: ${{ matrix.target }}
           SRC_DIR: ./
           EXTRA_FILES: "README.md"
-          # New feature which will be introduced to upstream by https://github.com/rust-build/rust-build.action/pull/17
           ARCHIVE_TYPES: "tar.gz zip"
   publish-cratesio:
     name: Publish to crates.io


### PR DESCRIPTION
Both https://github.com/rust-build/rust-build.action/pull/18 and https://github.com/rust-build/rust-build.action/pull/17 were released, so we can switch to the latest release of the action.