### PR TITLE
chore: fix builds and asset uploads in GitHub Actions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request: {}
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,25 +14,30 @@ name: Continuous integration
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        arch:
-          - aarch64
-          - x86_64
-        os:
-          - unknown-linux-gnu
-          - apple-darwin
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: x86_64-apple-darwin
+            os: macos-11
+          - target: aarch64-apple-darwin
+            os: macos-11
+          - target: x86_64-pc-windows-msvc
+            os: windows-2022
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3.1.0
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
-          target: ${{ matrix.arch }}-${{ matrix.os }}
+          target: ${{ matrix.target }}
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
+      - uses: Swatinem/rust-cache@v2.2.0
+      - uses: actions-rs/cargo@v1.0.1
         with:
           command: check
 
@@ -40,19 +45,19 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - run: |
           curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
           chmod 700 get_helm.sh
           ./get_helm.sh
           helm version --client
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
+      - uses: Swatinem/rust-cache@v2.2.0
+      - uses: actions-rs/cargo@v1.0.1
         with:
           command: test
 
@@ -60,15 +65,15 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3.1.0
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.2.0
       - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1.0.1
         with:
           command: fmt
           args: --all -- --check
@@ -77,15 +82,15 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3.1.0
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.2.0
       - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1.0.1
         with:
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Update Release Draft
     steps:
-      - uses: actions/checkout@v2
-      - uses: release-drafter/release-drafter@v5
+      - uses: actions/checkout@v3.1.0
+      - uses: release-drafter/release-drafter@v5.21.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,8 @@ name: Build
 
 on:
   release:
-    types: [created]
+    types:
+      - published
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
           profile: minimal
           override: true
           target: ${{ matrix.target }}
+      - uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,11 +6,9 @@ on:
       - published
 
 jobs:
-  build:
-    name: Build
+  build-and-upload:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
       matrix:
         # arch:
         #   - aarch64
@@ -26,17 +24,27 @@ jobs:
           - target: aarch64-unknown-linux-gnu
           - target: aarch64-apple-darwin
     steps:
-      - uses: actions/checkout@v2.5.0
-      - name: Compile
-        id: compile
-        uses: rust-build/rust-build.action@v1.4.0
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
         with:
-          RUSTTARGET: ${{ matrix.target }}
-          UPLOAD_MODE: none
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
         with:
-          name: Binary
-          path: |
-            ${{ steps.compile.outputs.BUILT_ARCHIVE }}
-            ${{ steps.compile.outputs.BUILT_CHECKSUM }}
+          use-cross: true
+          command: build
+          args: --release --target ${{ matrix.target }}
+      - shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czvf ../../../helm-templexer-${{ matrix.target }}.tar.gz helm-templexer
+          cd -
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./helm-templexer-${{ matrix.target }}.tar.gz
+          asset_name: helm-templexer-${{ matrix.target }}.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,15 +42,15 @@ jobs:
       - shell: bash
         run: |
           cd target/${{ matrix.target }}/release
-          tar czvf ../../../helm-templexer-${{ matrix.target }}.tar.gz helm-templexer*
+          tar czvf ../../../helm-templexer-${{ github.ref_name }}-${{ matrix.target }}.tar.gz helm-templexer*
           cd -
       - uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./helm-templexer-${{ matrix.target }}.tar.gz
-          asset_name: helm-templexer-${{ matrix.target }}.tar.gz
+          asset_path: ./helm-templexer-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
+          asset_name: helm-templexer-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
           asset_content_type: application/gzip
   publish-cratesio:
     name: Publish to crates.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,10 +5,16 @@ on:
     types:
       - published
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
-  build-and-upload:
-    runs-on: ubuntu-latest
+  release-binaries:
+    name: Release ${{ matrix.target }}
+    runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-pc-windows-gnu
@@ -18,13 +24,16 @@ jobs:
           # - target: x86_64-apple-darwin
           # - target: aarch64-apple-darwin
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
           target: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: shared-cache
       - uses: actions-rs/cargo@v1
         with:
           use-cross: true
@@ -43,3 +52,66 @@ jobs:
           asset_path: ./helm-templexer-${{ matrix.target }}.tar.gz
           asset_name: helm-templexer-${{ matrix.target }}.tar.gz
           asset_content_type: application/gzip
+  publish-cratesio:
+    name: Publish to crates.io
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: shared-cache
+      - uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  containerize:
+    name: Build & push container image
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: shared-cache
+      - name: Build binary
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target x86_64-unknown-linux-musl
+          use-cross: true
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,17 +12,21 @@ env:
 jobs:
   release-binaries:
     name: Release ${{ matrix.target }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-pc-windows-gnu
           - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-          # see <https://github.com/cross-rs/cross-toolchains
-          # - target: x86_64-apple-darwin
-          # - target: aarch64-apple-darwin
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macOS-latest
+          - target: aarch64-apple-darwin
+            os: macOS-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -36,7 +40,6 @@ jobs:
           sharedKey: shared-cache
       - uses: actions-rs/cargo@v1
         with:
-          use-cross: true
           command: build
           args: --release --target ${{ matrix.target }}
       - shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,9 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-musl
+          - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: aarch64-unknown-linux-musl
+          - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macOS-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
           - target: x86_64-apple-darwin
           - target: aarch64-unknown-linux-gnu
-          - target: aarch64-apple-darwin
+          # - target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
         id: compile
         uses: rust-build/rust-build.action@v1.4.0
         with:
-          RUSTTARGET: ${{ matrix.arch }}-$ {{ matrix.os }}
+          RUSTTARGET: ${{ matrix.arch }}-${{ matrix.os }}
           UPLOAD_MODE: none
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: Build
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [created]
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,18 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # arch:
-        #   - aarch64
-        #   - x86_64
-        # os:
-        #   - unknown-linux-musl
-        #   - apple-darwin
-        #   - pc-windows-gnu
         include:
           - target: x86_64-pc-windows-gnu
           - target: x86_64-unknown-linux-gnu
-          # - target: x86_64-apple-darwin
           - target: aarch64-unknown-linux-gnu
+          # see <https://github.com/cross-rs/cross-toolchains
+          # - target: x86_64-apple-darwin
           # - target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v1
@@ -39,7 +33,7 @@ jobs:
       - shell: bash
         run: |
           cd target/${{ matrix.target }}/release
-          tar czvf ../../../helm-templexer-${{ matrix.target }}.tar.gz helm-templexer
+          tar czvf ../../../helm-templexer-${{ matrix.target }}.tar.gz helm-templexer*
           cd -
       - uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,9 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macOS-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,27 +18,27 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - target: x86_64-apple-darwin
-            os: macOS-latest
+            os: macos-11
           - target: aarch64-apple-darwin
-            os: macOS-latest
+            os: macos-11
           - target: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: windows-2022
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3.1.0
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           toolchain: stable
           profile: minimal
           override: true
           target: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.2.0
         with:
           sharedKey: shared-cache
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1.0.1
         with:
           use-cross: true
           command: build
@@ -48,7 +48,7 @@ jobs:
           cd target/${{ matrix.target }}/release
           tar czvf ../../../helm-templexer-${{ github.ref_name }}-${{ matrix.target }}.tar.gz helm-templexer*
           cd -
-      - uses: actions/upload-release-asset@v1
+      - uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -60,13 +60,13 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3.1.0
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.2.0
         with:
           sharedKey: shared-cache
       - uses: katyo/publish-crates@v1
@@ -79,17 +79,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3.1.0
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.2.0
         with:
           sharedKey: shared-cache
       - name: Build binary
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1.0.1
         with:
           command: build
           args: --release --target x86_64-unknown-linux-musl
@@ -100,20 +100,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4.1.1
         with:
           images: |
             ${{ env.IMAGE_NAME }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v3.2.0
         with:
           context: .
           push: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         include:
           - target: x86_64-pc-windows-gnu
           - target: x86_64-unknown-linux-gnu
-          - target: x86_64-apple-darwin
+          # - target: x86_64-apple-darwin
           - target: aarch64-unknown-linux-gnu
           # - target: aarch64-apple-darwin
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,8 @@ jobs:
           - target: x86_64-unknown-linux-gnu
           - target: aarch64-unknown-linux-gnu
           # see <https://github.com/cross-rs/cross-toolchains
-          - target: x86_64-apple-darwin
-          - target: aarch64-apple-darwin
+          # - target: x86_64-apple-darwin
+          # - target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,98 +1,35 @@
-on:
-  release:
-    types:
-      - published
+name: Build
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+on:
+  push:
+    branches: [main]
 
 jobs:
-  release-binaries:
-    name: Release ${{ matrix.arch }}-${{ matrix.os }}
-    runs-on: ubuntu-20.04
+  build:
+    name: Build
+    runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         arch:
           - aarch64
           - x86_64
         os:
-          - unknown-linux-gnu
+          - unknown-linux-musl
           - apple-darwin
+          - pc-windows-gnu
     steps:
-      - uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v1
+      - uses: actions/checkout@v2.5.0
+      - name: Compile
+        id: compile
+        uses: rust-build/rust-build.action@v1.4.0
         with:
-          sharedKey: shared-cache
-      - name: Compile and release
-        uses: rust-build/rust-build.action@v1.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUSTTARGET: ${{ matrix.arch }}-${{ matrix.os }}
-          SRC_DIR: ./
-          EXTRA_FILES: "README.md"
-          ARCHIVE_TYPES: "tar.gz zip"
-  publish-cratesio:
-    name: Publish to crates.io
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+          RUSTTARGET: ${{ matrix.arch }}-$ {{ matrix.os }}
+          UPLOAD_MODE: none
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v1
-        with:
-          sharedKey: shared-cache
-      - uses: katyo/publish-crates@v1
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-  containerize:
-    name: Build & push container image
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v1
-        with:
-          sharedKey: shared-cache
-      - name: Build binary
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target x86_64-unknown-linux-musl
-          use-cross: true
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: |
-            ${{ env.IMAGE_NAME }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          name: Binary
+          path: |
+            ${{ steps.compile.outputs.BUILT_ARCHIVE }}
+            ${{ steps.compile.outputs.BUILT_CHECKSUM }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,20 +12,26 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        arch:
-          - aarch64
-          - x86_64
-        os:
-          - unknown-linux-musl
-          - apple-darwin
-          - pc-windows-gnu
+        # arch:
+        #   - aarch64
+        #   - x86_64
+        # os:
+        #   - unknown-linux-musl
+        #   - apple-darwin
+        #   - pc-windows-gnu
+        include:
+          - target: x86_64-pc-windows-gnu
+          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-apple-darwin
+          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v2.5.0
       - name: Compile
         id: compile
         uses: rust-build/rust-build.action@v1.4.0
         with:
-          RUSTTARGET: ${{ matrix.arch }}-${{ matrix.os }}
+          RUSTTARGET: ${{ matrix.target }}
           UPLOAD_MODE: none
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,8 @@ jobs:
           - target: x86_64-unknown-linux-gnu
           - target: aarch64-unknown-linux-gnu
           # see <https://github.com/cross-rs/cross-toolchains
-          # - target: x86_64-apple-darwin
-          # - target: aarch64-apple-darwin
+          - target: x86_64-apple-darwin
+          - target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           sharedKey: shared-cache
       - uses: actions-rs/cargo@v1.0.1
         with:
-          use-cross: true
+          use-cross: false
           command: build
           args: --release --target ${{ matrix.target }}
       - shell: bash

--- a/src/render_cmd.rs
+++ b/src/render_cmd.rs
@@ -50,7 +50,7 @@ impl RenderCmd {
                 config_file: Some(file.clone()),
                 ..Default::default()
             };
-            let cfg = Config::load(&file)?;
+            let cfg = Config::load(file)?;
             cfg.switch_working_directory(file)?.validate(&opts)?;
 
             let plan = self.plan(&cfg)?;


### PR DESCRIPTION
- Fix a Clippy error which was causing the test action to fail (inadvertent use of a reference).
- Rework the build action to successfully create releases for Linux on x86_64 and arm64 (and also create Windows binaries). Darwin binaries cannot be built using Cross without additional effort due to licensing issues, which are linked in the action yaml. (`rust-build` supports Darwin but only on x86.)

Note that the Brewfile at https://github.com/hendrikmaus/homebrew-tap hardcodes paths and so doesn't pick up on these artefacts.