### PR TITLE
fix(cd): re-enable `cross` in containerise job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,7 +119,7 @@ jobs:
         with:
           command: build
           args: --release --target x86_64-unknown-linux-musl
-          use-cross: false
+          use-cross: true
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:


### PR DESCRIPTION
I forgot to re-enable `cross` in the containerisation job.