### PR TITLE
fix(cd): pass release upload url to binary build job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      upload_url: ${{ steps.release.outputs.upload_url }}
     steps:
       - name: Release Please
         uses: google-github-actions/release-please-action@v3.6.1
@@ -70,7 +71,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
+          upload_url: ${{ needs.release-please.outputs.upload_url }}
           asset_path: ./helm-templexer-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
           asset_name: helm-templexer-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
           asset_content_type: application/gzip


### PR DESCRIPTION
With the switch to release-please, the source of the upload url for the binaries changed. This change-set passes that url along from the first job to the binary builder job.